### PR TITLE
Both prevent circle cropping on images which are too small, and if it…

### DIFF
--- a/images/image_operations.py
+++ b/images/image_operations.py
@@ -4,6 +4,10 @@ from wagtail.wagtailimages.image_operations import FillOperation
 
 class CircleOperation(FillOperation):
     def run(self, willow, image):
+        if image.width < self.width or image.height < self.height:
+            # unable to process image at all since the putalpha will fail
+            return
+
         super(CircleOperation, self).run(willow, image)
 
         mask_size = (3 * self.width, 3 * self.height)
@@ -48,6 +52,10 @@ class CircleWithRingOperation(FillOperation):
         super(CircleWithRingOperation, self).construct(size, *unprocessed_extra)
 
     def run(self, willow, image):
+        if image.width < self.width or image.height < self.height:
+            # unable to process image at all since the putalpha will fail
+            return
+
         super(CircleWithRingOperation, self).run(willow, image)
         willow.original_format = 'png'
 

--- a/images/wagtail_hooks.py
+++ b/images/wagtail_hooks.py
@@ -1,10 +1,14 @@
 from __future__ import absolute_import
 
+import logging
+
 from PIL import ImageDraw
 from wagtail.wagtailcore import hooks
 from willow.backends.pillow import PillowBackend
 
 from . import image_operations
+
+logger = logging.getLogger(__name__)
 
 
 @hooks.register('register_image_operations')
@@ -17,7 +21,12 @@ def register_image_operations():
 
 @PillowBackend.register_operation('putalpha')
 def putalpha(backend, alpha):
-    backend.image.putalpha(alpha)
+    try:
+        backend.image.putalpha(alpha)
+    except ValueError as e:
+        # Log exception but return and don't apply the operation.
+        logger.exception(e)
+        return
 
 
 @PillowBackend.register_operation('draw_bitmap')


### PR DESCRIPTION
… happen, catch and log the expection rather than have the page fail to load.